### PR TITLE
Fix/fe 7/carousel

### DIFF
--- a/components/cardVideo/cardVideo.tsx
+++ b/components/cardVideo/cardVideo.tsx
@@ -33,7 +33,7 @@ type Props = iCard | iPlaySVG | iScoreSVG;
     <div className='max-w-sm rounded overflow-hidden shadow-lg'>
       <div  className="flex justify-center">
         <img src={src} alt="course" style={{height: '188px'}}/>
-         <div  className={`${styles.mtPlay} absolute`}>
+         <div  className='place-self-center absolute'>
         <IconPlaySVG size={size} />
          </div>
       </div>

--- a/components/videoCardList/videoCardList.tsx
+++ b/components/videoCardList/videoCardList.tsx
@@ -26,7 +26,7 @@ const VideoCardList: React.FC<iVideoList> = ({ cards, setPrevVideoIndex, setNext
       <ArrowPrevSVG onPrev={setPrevVideoIndex} />
       {cards.map((card) => {
         return (
-          <div key={card.alt} className={`${styles.wImg} mx-2 bg-white`}>
+          <div key={card.alt} className='w-full mx-2 bg-white'>
             <CardVideo {...card} />
           </div>
         );

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -128,10 +128,6 @@
   height: 1em;
 }
 
-.w-img {
-  width: 100%;
-}
-
 @media (max-width: 600px) {
   .grid {
     width: 100%;

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -129,7 +129,7 @@
 }
 
 .w-img {
-  width: 235px;
+  width: 100%;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## What does this PR do?

Just one change in style card list for carousel width to make the carousel look complete on-screen and center button play.

## Review

- Only check on the screen to width complete of the card list.
- Pull branch fix/FE-7/carousel
- Check styles card list change to width 100%, after replace styles/Home.module.css for tailwind in components/videoCardList/videoCardList.tsx
- Review on-page that is complete the width on the list
-  Center button play components/cardVideo/cardVideo.tsx and review on page and storybook

## What are the relevant tickets?

https://trello.com/c/0ICdR2lQ/10-fe-7create-carousel-component

## Screenshots

- Before

![Screen Shot 2020-12-06 at 8 54 42](https://user-images.githubusercontent.com/56928486/101283684-968cbc00-37a1-11eb-8fe8-eb4c1f52e30b.png)

- After

![Screen Shot 2020-12-06 at 8 55 39](https://user-images.githubusercontent.com/56928486/101283695-a6a49b80-37a1-11eb-8e4f-78578f59c5fa.png)

:camera:

## Questions

Could you please review this change, please @jonathanperazawl @ivanovishado? 

:question: